### PR TITLE
PHY: Respect bus free time

### DIFF
--- a/litei2c/clkgen.py
+++ b/litei2c/clkgen.py
@@ -45,12 +45,16 @@ class LiteI2CClkGen(LiteXModule):
 
     keep_low : Signal(), in
         Forces the clock to be low, when the clock is disabled.
+
+    suppress : Signal(), in
+        Disables the clock output.
     """
     def __init__(self, pads, i2c_speed_mode, sys_clk_freq):
         self.tx         = tx         = Signal()
         self.rx         = rx         = Signal()
         self.en         = en         = Signal()
         self.keep_low   = keep_low   = Signal()
+        self.suppress   = suppress   = Signal()
     
         cnt_width = bits_for(freq_to_div(sys_clk_freq, 100000))
     
@@ -93,8 +97,8 @@ class LiteI2CClkGen(LiteXModule):
 
         self.specials += SDRTristate(
             io = pads.scl,
-            o  = Signal(),      # I2C uses Pull-ups, only drive low.
-            oe = ~clk,          # Drive when scl is low.
-            i  = Signal(),      # Not used.
+            o  = Signal(),          # I2C uses Pull-ups, only drive low.
+            oe = ~clk & ~suppress,  # Drive when scl is low and not suppressed.
+            i  = Signal(),          # Not used.
         )
 

--- a/litei2c/phy/generic.py
+++ b/litei2c/phy/generic.py
@@ -205,8 +205,6 @@ class LiteI2CPHYCore(LiteXModule):
             )
         )
 
-
-
         fsm.act("PRE-TX",
             clkgen.en.eq(1),
             NextValue(sr_cnt, 0),
@@ -261,8 +259,6 @@ class LiteI2CPHYCore(LiteXModule):
                 ),
             ),
         )
-
-        fsm.act
 
         fsm.act("TX-BEFORE-NEXT",
             # Generate Clk.
@@ -464,6 +460,15 @@ class LiteI2CPHYCore(LiteXModule):
             source.valid.eq(1),
             source.last.eq(1),
             If(source.ready,
+                NextState("BUS-FREE"),
+            )
+        )
+
+        fsm.act("BUS-FREE",
+            If(~clkgen.rx,
+                clkgen.en.eq(1),
+                clkgen.suppress.eq(1),
+            ).Else(
                 NextState("WAIT-DATA"),
             )
         )


### PR DESCRIPTION
This makes the PHY wait for at least bus free time after each transaction. Now, it is possible to correctly handle multiple simultaneous requests.

Fixes #1